### PR TITLE
clang/gcc compatibility

### DIFF
--- a/XcodeProjAdder/IOMethods.cpp
+++ b/XcodeProjAdder/IOMethods.cpp
@@ -8,6 +8,9 @@
 //  DON'T BE A DICK PUBLIC LICENSE TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
 //
 
+#include <cerrno>
+#include <cstdlib>
+
 #include "IOMethods.h"
 
 std::string IOMethods::generateOSXUUID()

--- a/XcodeProjAdder/main.cpp
+++ b/XcodeProjAdder/main.cpp
@@ -8,6 +8,8 @@
 //  DON'T BE A DICK PUBLIC LICENSE TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
 //
 
+#include <cstring>
+
 #include "xprojRestorer.h"
 #include "xprojFileAdder.h"
 

--- a/XcodeProjAdder/xprojFileAdder.cpp
+++ b/XcodeProjAdder/xprojFileAdder.cpp
@@ -8,6 +8,8 @@
 //  DON'T BE A DICK PUBLIC LICENSE TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
 //
 
+#include <cstdlib>
+
 #include "xprojFileAdder.h"
 
 void addFilesToXproj(std::string projectFileLocation, std::string sourceFilePathCSV)

--- a/XcodeProjAdder/xprojZoneFileTools.cpp
+++ b/XcodeProjAdder/xprojZoneFileTools.cpp
@@ -19,6 +19,8 @@
  *
  */
 
+#include <algorithm>
+
 #include "xprojZoneFileTools.h"
 
 //File types currently supported by this tool


### PR DESCRIPTION
Requires C++11, compile with:

```
g++ -std=c++11 *.cpp -o xc
```
