### PR TITLE
Allow to add folders in the comma separated list of files to be included

### DIFF
--- a/XcodeProjAdder/IOMethods.cpp
+++ b/XcodeProjAdder/IOMethods.cpp
@@ -10,6 +10,10 @@
 
 #include <cerrno>
 #include <cstdlib>
+#include <dirent.h>
+#include <unistd.h>
+#include <sys/stat.h>
+#include <sys/types.h>
 
 #include "IOMethods.h"
 
@@ -51,4 +55,72 @@ std::string IOMethods::get_file_contents(std::string filename)
         std::cout << "\n\nERROR: Looks like I cannot read your Xcode project file, make sure the path to your '.xcodeproj' is fully qualified and that you have both read and write permissions\n\n";
         exit(1);
     }
+}
+
+
+
+inline bool ends_with(std::string const & value, std::string const & ending) {
+    if (ending.size() > value.size()) return false;
+    return std::equal(ending.rbegin(), ending.rend(), value.rbegin());
+}
+inline bool starts_with(std::string const & value, std::string const & start) {
+    if (start.size() > value.size()) return false;
+    return std::equal(start.begin(), start.end(), value.begin());
+}
+
+std::vector<std::string> IOMethods::expand_dirs(std::vector<std::string> filenames) {
+    std::vector<std::string> result;
+    
+    DIR *d = NULL;
+    struct dirent *dir;
+    struct stat s;
+    
+    for (auto it = filenames.begin(); it != filenames.end(); it++) {
+        std::string filename = *it;
+        
+        // Drop the last "/" in case of a directory
+        if (ends_with(filename, "/")) {
+            filename = filename.substr(0, filename.size()-1);
+        }
+        
+        if (stat(filename.c_str(), &s) != 0) {
+            continue; // error
+        }
+        
+        if (s.st_mode & S_IFREG) {
+            // Regular file: add to result
+            result.push_back(filename);
+        }
+        
+        else if( s.st_mode & S_IFDIR ) {
+            // Directory
+            
+            d = opendir(filename.c_str());
+            if (d == NULL) {
+                continue; //error
+            }
+            
+            std::vector<std::string> dir_contents;
+            
+            while ((dir = readdir(d)) != NULL) {
+                std::string name = std::string(dir->d_name);
+                
+                if (starts_with(name, ".")) {
+                    // ignore ".", ".." and hidden files like ".DS_STORE"
+                    continue;
+                }
+                
+                dir_contents.push_back(filename + "/" + name);
+            }
+
+            // recursive call to get contents of each subdirectory
+            std::vector<std::string> dir_result = IOMethods::expand_dirs(dir_contents);
+            
+            // add all the files to the result
+            result.insert(result.end(), dir_result.begin(), dir_result.end());
+        }
+    }
+    
+    return result;
+
 }

--- a/XcodeProjAdder/IOMethods.h
+++ b/XcodeProjAdder/IOMethods.h
@@ -20,9 +20,12 @@ namespace IOMethods
 {
     //Generates a 24 char UUID string in OSX
     std::string generateOSXUUID();
-
+    
     //Retrieves file contents as string
     std::string get_file_contents(std::string filename);
+    
+    //Given a list if files, expand it so that all directory paths are converted to their contents
+    std::vector<std::string> expand_dirs(std::vector<std::string> filenames);
 }
 
 #endif

--- a/XcodeProjAdder/xprojFileAdder.cpp
+++ b/XcodeProjAdder/xprojFileAdder.cpp
@@ -21,6 +21,7 @@ void addFilesToXproj(std::string projectFileLocation, std::string sourceFilePath
     std::string initialProjectContent = IOMethods::get_file_contents(projectFileLocation);
     std::string transformedProjectContent = initialProjectContent;
     std::vector<std::string> sourceFilePaths = split(sourceFilePathCSV, ',');
+    sourceFilePaths =  IOMethods::expand_dirs(sourceFilePaths);
     std::cout <<  "\n";
     
     for(std::vector<std::string>::iterator it = sourceFilePaths.begin(); it != sourceFilePaths.end(); ++it)


### PR DESCRIPTION
The tool can now handle arguments like `-SCSV /path/to/file,/path/to/folder`
It will walk through the folder and add the files separately to the project as if they were listed with commas between them.

I used a Unix-only approach, so this might not be compatible with Windows. However, I assume that is no concern for a project that is about building for a OSX-only tool.
